### PR TITLE
Fix typo in intentional culture article

### DIFF
--- a/src/content/articles/designing-intentional-culture.mdx
+++ b/src/content/articles/designing-intentional-culture.mdx
@@ -89,7 +89,7 @@ Needfinding contributes to empathy, customer focus, human-centredness, understan
 
 #### Ideation
 
-Ideation contributes to ambiguity resilience, promotes managed risk-taking, develops collaborative skills, co-design skills and cooperation skills. Ideation helps you imagine a new and different future. What might your culture look like? What sort of rituals and traditions will support the culture you want? What human experiences and tangible artefacts will drive the culture you envision. We use a wide variety of exercises. Thes include round-robin, opposite thinking, mash-ups, storyboarding, rip and rap and brainstorming, and there are many more.
+Ideation contributes to ambiguity resilience, promotes managed risk-taking, develops collaborative skills, co-design skills and cooperation skills. Ideation helps you imagine a new and different future. What might your culture look like? What sort of rituals and traditions will support the culture you want? What human experiences and tangible artefacts will drive the culture you envision. We use a wide variety of exercises. These include round-robin, opposite thinking, mash-ups, storyboarding, rip and rap and brainstorming, and there are many more.
 
 #### Action
 


### PR DESCRIPTION
## Summary
- correct a typo in the `designing-intentional-culture` article

## Testing
- `npm test` *(fails: search functionality tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_683f96b62674832fad0576639ec01c3d